### PR TITLE
Feat: auto deploy aws

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - 'v*'
 
 env:
+  GITHUB_PUSH_TOKEN: ${{ secrets.INTERSCRIPT_CI_PAT }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
@@ -56,3 +57,12 @@ jobs:
 #          RUBYGEMS_API_KEY: ${{secrets.INTERSCRIPT_RUBYGEMS_API_KEY}}
         run: |
           echo "TODO"
+
+      - name: Dispatch interscript-infra publish to AWS Lambda
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ env.GITHUB_PUSH_TOKEN }}
+          repository: phuonghuynh/testci3
+          event-type: ${{ github.repository }}
+          client-payload: '{ "workflow": "terraform", "interscript_version": "${{env.INTERSCRIPT_VERSION}}" }'
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,6 @@ jobs:
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ env.GITHUB_PUSH_TOKEN }}
-          repository: phuonghuynh/testci3
+          repository: interscript/infrastructure
           event-type: ${{ github.repository }}
           client-payload: '{ "workflow": "terraform", "interscript_version": "${{env.INTERSCRIPT_VERSION}}" }'
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,12 +52,6 @@ jobs:
             ${{env.AWSL_SRC_ZIP}}
             ${{env.AWSL_LAYER_ZIP}}
 
-      - name: Publish to AWS Lambda
-#        env:
-#          RUBYGEMS_API_KEY: ${{secrets.INTERSCRIPT_RUBYGEMS_API_KEY}}
-        run: |
-          echo "TODO"
-
       - name: Dispatch interscript-infra publish to AWS Lambda
         uses: peter-evans/repository-dispatch@v1
         with:

--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -23,7 +23,6 @@ jobs:
     - name: Create API Release
       uses: actions/create-release@v1
       env:
-        ## must use this token to trigger release workflow
         GITHUB_TOKEN: ${{env.GITHUB_PUSH_TOKEN}}
       with:
         tag_name: v${{env.INTERSCRIPT_VERSION}}
@@ -31,32 +30,3 @@ jobs:
         body: Auto release API v${{env.INTERSCRIPT_VERSION}} by @interscript-ci
         draft: false
         prerelease: false
-
-#    - name: Add writable remote
-#      run: |
-#        git config --global user.name "interscript-ci"
-#        git config --global user.email "interscript-ci@users.noreply.github.com"
-#        git remote add github "https://metanorma-ci:${{ secrets.INTERSCRIPT_CI_PAT }}@github.com/$GITHUB_REPOSITORY.git"
-#        git pull github ${GITHUB_REF} --ff-only
-#    - name: Parse interscript version
-#      env:
-#        INTERSCRIPT_TAG: ${{ github.event.client_payload.ref }}
-#      run: |
-#        echo "::set-env name=INTERSCRIPT_VERSION::${INTERSCRIPT_TAG#*/v}"
-#    - uses: actions/setup-ruby@v1
-#      with:
-#        ruby-version: '2.6'
-#    - name: Install bundler
-#      run: |
-#        gem install bundler
-#    - name: Update version
-#      run: |
-#        bundle remove interscript
-#        bundle add interscript -v ${INTERSCRIPT_VERSION}
-#        bundle install --deployment
-#    - name: Push commit and tag
-#      run: |
-#        git add Gemfile
-#        git commit -m "Bump version to ${INTERSCRIPT_VERSION}.0"
-#        git tag v${INTERSCRIPT_VERSION}.0
-#        git push github HEAD:${GITHUB_REF} --tags


### PR DESCRIPTION
Support auto release [-api](https://github.com/interscript/interscript-api) and aws-lambda [-aws-lambda](https://github.com/interscript/infrastructure)

Workflow:
1. Manual create a new GitHub Release new gem from [interscript repo](https://github.com/interscript/interscript)
2. (GHA) Auto dispatch the build an publish new GitHub Release for [-api](https://github.com/interscript/interscript-api), same version as the gem
3.  (GHA) Auto dispatch [-infrastructure](https://github.com/interscript/infrastructure) to deploy to aws lambda and push .statefile to github, all process should be done successfully. A new Pull Request is created and assigned to predefined [`.pr_reviewers`](https://github.com/interscript/infrastructure/blob/feat-auto-deploy-aws/.github/.pr_reviewers) to approve statefile changed and manual merge to master branch of  [-infrastructure](https://github.com/interscript/infrastructure)


Secrets variable required:
1. (might be done) Push permission token: `INTERSCRIPT_CI_PAT` in [-api](https://github.com/interscript/interscript-api) and [-infrastructure](https://github.com/interscript/infrastructure)
2. [-infrastructure](https://github.com/interscript/infrastructure): `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
3. [`.pr_reviewers`](https://github.com/interscript/infrastructure/blob/feat-auto-deploy-aws/.github/.pr_reviewers): static csv string Reviewers assigned when Pull Request sent in [-infrastructure](https://github.com/interscript/infrastructure) after applying AWS Lambda successfully.

Related issue #12, #15, #3